### PR TITLE
ENG-3006 Updating owasp suppression file location for the core-parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
             https://raw.githubusercontent.com/entando/entando-core-parent/v${project.parent.version}/checkstyle.xml
         </checkstyleConfigLocation>
         <owaspSuppressionFileLocation>
-            https://raw.githubusercontent.com/entando/entando-core-parent/v${project.parent.version}/owasp-dependency-check-suppression.xml
+            owasp-dependency-check-suppression.xml
         </owaspSuppressionFileLocation>
         <!--test database default settings -->
         <test.database.driver>org.apache.derby.jdbc.EmbeddedDriver</test.database.driver>


### PR DESCRIPTION
This owasp suppression file location makes sense in the children projects because it looks for the core-parent version and gets its suppression file, but for the core-parent itself its broken because it gets its own parent version, in this case 6.3.5, and it finds an old suppression file for the entando-core-parent suppression. The core-parent needs to reference its own suppression file and the way it was this line it needs to be added to all children projects.