### PR TITLE
ENG-5128 Update vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <lucene-core.version>7.2.0</lucene-core.version>
         <argon2-jvm.version>2.2</argon2-jvm.version>
         <json-path-assert.version>2.2.0</json-path-assert.version>
-        <springfox-swagger2.version>2.10.5</springfox-swagger2.version>
+        <springfox-swagger2.version>2.8.0</springfox-swagger2.version>
         <byte-buddy.version>1.9.10</byte-buddy.version>
         <guava.version>30.0-jre</guava.version>
         <spring-data-rest-webmvc.version>3.5.6</spring-data-rest-webmvc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <springsecurity.version>5.5.7</springsecurity.version>
         <springsecurityoauth2.version>2.5.2.RELEASE</springsecurityoauth2.version>
         <spring-session-data-redis.version>2.7.0</spring-session-data-redis.version>
-        <struts2.version>2.5.26</struts2.version>
+        <struts2.version>2.5.31</struts2.version>
         <cxf.version>3.3.10</cxf.version>
         <jackson.version>2.11.4</jackson.version>
         <hibernate-validator-version>6.0.20.Final</hibernate-validator-version>
@@ -84,7 +84,7 @@
         <springfox-swagger2.version>2.10.5</springfox-swagger2.version>
         <byte-buddy.version>1.9.10</byte-buddy.version>
         <guava.version>30.0-jre</guava.version>
-        <spring-data-rest-webmvc.version>3.1.3.RELEASE</spring-data-rest-webmvc.version>
+        <spring-data-rest-webmvc.version>3.5.6</spring-data-rest-webmvc.version>
         <commons-beanutils.version>1.9.4</commons-beanutils.version>
         <commons-chain.version>1.2</commons-chain.version>
         <commons-text.version>1.10.0</commons-text.version>
@@ -138,7 +138,7 @@
         <oro.version>2.0.8</oro.version>
         <xom.version>1.2.5</xom.version>
         <esapi.version>2.4.0.0</esapi.version>
-        <tika-version>1.26</tika-version>
+        <tika-version>1.28.4</tika-version>
         <c3p0.version>0.9.5.4</c3p0.version>
         <vorbis-java-tika.version>0.8</vorbis-java-tika.version>
         <metadata-extractor.version>2.18.0</metadata-extractor.version>

--- a/pom.xml
+++ b/pom.xml
@@ -70,9 +70,9 @@
             jdbc:derby:${project.build.directory}/test/db/${project.artifactId}testServ;create=true
         </test.database.serv.url>
         <!--dependency versions-->
-        <spring.version>5.3.8</spring.version>
-        <springsecurity.version>5.5.1</springsecurity.version>
-        <springsecurityoauth2.version>2.5.1.RELEASE</springsecurityoauth2.version>
+        <spring.version>5.3.27</spring.version>
+        <springsecurity.version>5.5.7</springsecurity.version>
+        <springsecurityoauth2.version>2.5.2.RELEASE</springsecurityoauth2.version>
         <spring-session-data-redis.version>2.7.0</spring-session-data-redis.version>
         <struts2.version>2.5.26</struts2.version>
         <cxf.version>3.3.10</cxf.version>
@@ -81,22 +81,22 @@
         <lucene-core.version>7.2.0</lucene-core.version>
         <argon2-jvm.version>2.2</argon2-jvm.version>
         <json-path-assert.version>2.2.0</json-path-assert.version>
-        <springfox-swagger2.version>2.8.0</springfox-swagger2.version>
+        <springfox-swagger2.version>2.10.5</springfox-swagger2.version>
         <byte-buddy.version>1.9.10</byte-buddy.version>
         <guava.version>30.0-jre</guava.version>
         <spring-data-rest-webmvc.version>3.1.3.RELEASE</spring-data-rest-webmvc.version>
         <commons-beanutils.version>1.9.4</commons-beanutils.version>
         <commons-chain.version>1.2</commons-chain.version>
         <commons-text.version>1.10.0</commons-text.version>
-        <commons-codec.version>1.12</commons-codec.version>
+        <commons-codec.version>1.15</commons-codec.version>
         <commons-collections.version>3.2.2</commons-collections.version>
-        <commons-dbcp2.version>2.5.0</commons-dbcp2.version>
-        <freemarker.version>2.3.28</freemarker.version>
+        <commons-dbcp2.version>2.9.0</commons-dbcp2.version>
+        <freemarker.version>2.3.31</freemarker.version>
         <commons-validator.version>1.3.1</commons-validator.version>
         <taglibs-standard-impl.version>1.2.5</taglibs-standard-impl.version>
         <assertj-core.version>3.11.1</assertj-core.version>
         <commons-digester.version>1.8</commons-digester.version>
-        <logback.version>1.2.3</logback.version>
+        <logback.version>1.2.7</logback.version>
         <logback-json.version>0.1.5</logback-json.version>
         <aspectj.version>1.8.0</aspectj.version>
         <ormlite-jdbc.version>4.40</ormlite-jdbc.version>
@@ -137,11 +137,11 @@
         <xml-apis.version>1.4.01</xml-apis.version>
         <oro.version>2.0.8</oro.version>
         <xom.version>1.2.5</xom.version>
-        <esapi.version>2.1.0.1</esapi.version>
+        <esapi.version>2.4.0.0</esapi.version>
         <tika-version>1.26</tika-version>
         <c3p0.version>0.9.5.4</c3p0.version>
         <vorbis-java-tika.version>0.8</vorbis-java-tika.version>
-        <metadata-extractor.version>2.11.0</metadata-extractor.version>
+        <metadata-extractor.version>2.18.0</metadata-extractor.version>
         <commons-collections4.version>4.1</commons-collections4.version>
         <lombok.version>1.18.2</lombok.version>
         <maven-surefire-plugin.version>3.0.0-M4</maven-surefire-plugin.version>


### PR DESCRIPTION
The libs updates done here are the versions that are being used in app-engine and its already tested.
Here are the libs updates:

- org.springframework:spring-beans@5.3.8 -> 5.3.27
- com.drewnoakes:metadata-extractor@2.11.0 -> 2.18.0
- org.springframework.security:spring-security-web@5.5.1 -> 5.5.7
- org.springframework.security.oauth:spring-security-oauth2@2.5.1.RELEASE -> 2.5.2.RELEASE
- org.apache.struts:struts2-core@2.5.26 -> 2.5.31
- org.springframework.data:spring-data-rest-webmvc@3.1.3.RELEASE -> 3.5.6
- commons-codec:commons-codec@1.12 -> commons-codec:commons-codec@1.13
- org.apache.commons:commons-dbcp2@2.5.0 -> 2.9.0
- org.freemarker:freemarker@2.3.28 -> 2.3.30
- ch.qos.logback:logback-core@1.2.3 -> 1.2.7
- org.owasp.esapi:esapi@2.1.0.1 -> 2.3.0.0
- org.apache.tika:tika-parsers@1.26 -> 1.28.4

And those are the fixed vulnerabilities:

Critical:

- https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-2436751 (Upgrade org.springframework:spring-beans@5.3.8 to org.springframework:spring-beans@5.3.20)
- https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-3369852 (Upgrade org.springframework:spring-webmvc@5.3.8 to org.springframework:spring-webmvc@5.3.26)

High:

- https://security.snyk.io/vuln/SNYK-JAVA-COMDREWNOAKES-455419 (Upgrade com.drewnoakes:metadata-extractor@2.11.0 to com.drewnoakes:metadata-extractor@2.18.0)
- https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORKSECURITY-2833359 (Upgrade org.springframework.security:spring-security-web@5.5.1 to org.springframework.security:spring-security-web@5.5.7)
- https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORKSECURITYOAUTH-2772728 (Upgrade org.springframework.security.oauth:spring-security-oauth2@2.5.1.RELEASE to org.springframework.security.oauth:spring-security-oauth2@2.5.2.RELEASE)
- https://security.snyk.io/vuln/SNYK-JAVA-ORGOWASPESAPI-2803305 (Upgrade org.owasp.esapi:esapi@2.1.0.1 to org.owasp.esapi:esapi@2.3.0.0)
- https://security.snyk.io/vuln/SNYK-JAVA-ORGFREEMARKER-1076795 (Upgrade org.freemarker:freemarker@2.3.28 to org.freemarker:freemarker@2.3.30)
- https://security.snyk.io/vuln/SNYK-JAVA-COMGITHUBJUNRAR-2388979 (Upgrade org.apache.tika:tika-parsers@1.26 to org.apache.tika:tika-parsers@1.28.4)
- https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLEPROTOBUF-2331703 (Upgrade org.apache.tika:tika-parsers@1.26 to org.apache.tika:tika-parsers@1.28.4)
- https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHECOMMONS-1316641 (Upgrade org.apache.tika:tika-parsers@1.26 to org.apache.tika:tika-parsers@1.28.4)
- https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHEPDFBOX-1304912 (Upgrade org.apache.tika:tika-parsers@1.26 to org.apache.tika:tika-parsers@1.28.4)
- https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHEPDFBOX-1304913 (Upgrade org.apache.tika:tika-parsers@1.26 to org.apache.tika:tika-parsers@1.28.4)
- https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHEPOI-2419052 (Upgrade org.apache.tika:tika-parsers@1.26 to org.apache.tika:tika-parsers@1.28.4)
- https://security.snyk.io/vuln/SNYK-JAVA-ORGJDOM-1309669 (Upgrade org.apache.tika:tika-parsers@1.26 to org.apache.tika:tika-parsers@1.28.4)
- https://security.snyk.io/vuln/SNYK-JAVA-ORGJSOUP-1567345 (Upgrade org.apache.tika:tika-parsers@1.26 to org.apache.tika:tika-parsers@1.28.4)
- https://security.snyk.io/vuln/SNYK-JAVA-XERCES-2359991 (Upgrade org.apache.tika:tika-parsers@1.26 to org.apache.tika:tika-parsers@1.28.4)
- https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-2635340 (Upgrade org.apache.struts:struts2-core@2.5.26 to org.apache.struts:struts2-core@2.5.31)
- https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-5707102 (Upgrade org.apache.struts:struts2-core@2.5.26 to org.apache.struts:struts2-core@2.5.31)

Medium:

- https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-2329097 (Upgrade org.springframework:spring-core@5.3.8 to org.springframework:spring-core@5.3.14)
- https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-2330878 (Upgrade org.springframework:spring-core@5.3.8 to org.springframework:spring-core@5.3.14)
- https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-2434828 (Upgrade org.springframework:spring-expression@5.3.8 to org.springframework:spring-expression@5.3.27)
- https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-2823313 (Upgrade org.springframework:spring-beans@5.3.8 to org.springframework:spring-beans@5.3.20)
- https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-3369749 (Upgrade org.springframework:spring-expression@5.3.8 to org.springframework:spring-expression@5.3.27)
- https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-5422217 (Upgrade org.springframework:spring-expression@5.3.8 to org.springframework:spring-expression@5.3.27)
- https://security.snyk.io/vuln/SNYK-JAVA-COMDREWNOAKES-2413662 (Upgrade com.drewnoakes:metadata-extractor@2.11.0 to com.drewnoakes:metadata-extractor@2.18.0)
- https://security.snyk.io/vuln/SNYK-JAVA-COMDREWNOAKES-2413663 (Upgrade com.drewnoakes:metadata-extractor@2.11.0 to com.drewnoakes:metadata-extractor@2.18.0)
- https://security.snyk.io/vuln/SNYK-JAVA-ORGOWASPESAPI-2805301 (Upgrade org.owasp.esapi:esapi@2.1.0.1 to org.owasp.esapi:esapi@2.3.0.0)
- https://security.snyk.io/vuln/SNYK-JAVA-CHQOSLOGBACK-1726923 (Upgrade ch.qos.logback:logback-core@1.2.3 to ch.qos.logback:logback-core@1.2.7)
- https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORKSECURITY-2833360 (Upgrade org.springframework.security:spring-security-web@5.5.1 to org.springframework.security:spring-security-web@5.5.7)
- https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLECODEGSON-1730327 (Upgrade org.apache.tika:tika-parsers@1.26 to org.apache.tika:tika-parsers@1.28.4)
- https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHECOMMONS-1316638 (Upgrade org.apache.tika:tika-parsers@1.26 to org.apache.tika:tika-parsers@1.28.4)
- https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHECOMMONS-1316639 (Upgrade org.apache.tika:tika-parsers@1.26 to org.apache.tika:tika-parsers@1.28.4)
- https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHECOMMONS-1316640 (Upgrade org.apache.tika:tika-parsers@1.26 to org.apache.tika:tika-parsers@1.28.4)
- https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHETIKA-2825265 (Upgrade org.apache.tika:tika-core@1.26 to org.apache.tika:tika-core@1.28.4)
- https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHETIKA-2859197 (Upgrade org.apache.tika:tika-core@1.26 to org.apache.tika:tika-core@1.28.4)
- https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHETIKA-2936441 (Upgrade org.apache.tika:tika-core@1.26 to org.apache.tika:tika-core@1.28.4)
- https://security.snyk.io/vuln/SNYK-JAVA-ORGBOUNCYCASTLE-2841508 (Upgrade org.apache.tika:tika-parsers@1.26 to org.apache.tika:tika-parsers@1.28.4)
- https://security.snyk.io/vuln/SNYK-JAVA-ORGJSOUP-2989728 (Upgrade org.apache.tika:tika-parsers@1.26 to org.apache.tika:tika-parsers@1.28.4)
- https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-5707101 (Upgrade org.apache.struts:struts2-core@2.5.26 to org.apache.struts:struts2-core@2.5.31)
- https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORKDATA-1767823 (Upgrade org.springframework.data:spring-data-rest-webmvc@3.1.3.RELEASE to org.springframework.data:spring-data-rest-webmvc@3.5.6)

Low:

- https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-2689634 (Upgrade org.springframework:spring-context@5.3.8 to org.springframework:spring-context@5.3.19)
- https://security.snyk.io/vuln/SNYK-JAVA-ORGOWASPESAPI-1088594 (Upgrade org.owasp.esapi:esapi@2.1.0.1 to org.owasp.esapi:esapi@2.3.0.0)
- https://security.snyk.io/vuln/SNYK-JAVA-COMMONSCODEC-561518 (Upgrade commons-codec:commons-codec@1.12 to commons-codec:commons-codec@1.13)
- https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHECOMMONS-559327 (Upgrade org.apache.commons:commons-dbcp2@2.5.0 to org.apache.commons:commons-dbcp2@2.9.0)